### PR TITLE
Performance improvements to UI camera

### DIFF
--- a/Assets/VRInputModule/Scripts/LaserPointerInputModule.cs
+++ b/Assets/VRInputModule/Scripts/LaserPointerInputModule.cs
@@ -51,6 +51,8 @@ namespace Wacki {
             UICamera.enabled = false;
             UICamera.fieldOfView = 5;
             UICamera.nearClipPlane = 0.01f;
+	        UICamera.cullingMask = LayerMask.NameToLayer("UI");//user must add canvases to a 'UI' layer
+	        UICamera.stereoTargetEye = StereoTargetEyeMask.None;
 
             // Find canvases in the scene and assign our custom
             // UICamera to them

--- a/Assets/VRInputModule/Scripts/LaserPointerInputModule.cs
+++ b/Assets/VRInputModule/Scripts/LaserPointerInputModule.cs
@@ -51,8 +51,8 @@ namespace Wacki {
             UICamera.enabled = false;
             UICamera.fieldOfView = 5;
             UICamera.nearClipPlane = 0.01f;
-	        UICamera.cullingMask = LayerMask.NameToLayer("UI");//user must add canvases to a 'UI' layer
-	        UICamera.stereoTargetEye = StereoTargetEyeMask.None;
+	    UICamera.cullingMask = layerMask;//user must add canvases to a 'UI' layer
+	    UICamera.stereoTargetEye = StereoTargetEyeMask.None;
 
             // Find canvases in the scene and assign our custom
             // UICamera to them


### PR DESCRIPTION
Additional canvas camera was causing lag spikes. They now cull exerything except canvases on the "UI" layer.  Also add stereoTargetEye.None instead of Both(default). 

The ultimate would be to find a solution that didn't require a camera.